### PR TITLE
Fix Regex issue

### DIFF
--- a/diff.py
+++ b/diff.py
@@ -15,7 +15,7 @@ from shutil import copyfile
 FLOAT_REGEXP = re.compile(r'\d+\.\d+')
 DATETIME_REGEXP = re.compile(r'\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}')
 COMMAND_REGEXP = re.compile(r'<p>(<strong>)?Command used:.*')
-OUTPUT_REGEXP = re.compile(r'.*/CRISPResso2*/cli_integration_tests/CRISPResso*')
+OUTPUT_REGEXP = re.compile(r'[\S]*/CRISPResso2[\S]*/cli_integration_tests/CRISPResso[\S]*')
 IGNORE_FILES = frozenset([
     'CRISPResso_RUNNING_LOG.txt',
     'CRISPRessoBatch_RUNNING_LOG.txt',
@@ -80,7 +80,7 @@ def substitute_line(line):
     line = FLOAT_REGEXP.sub(round_float, line)
     line = DATETIME_REGEXP.sub('2024-01-11 12:34:56', line)
     line = COMMAND_REGEXP.sub('<p>Command used: <command></p>', line)
-    line = OUTPUT_REGEXP.sub('output_folder: CRISPResso2_tests/cli_integration_tests/CRISPResso', line)
+    line = OUTPUT_REGEXP.sub('CRISPResso2_tests/cli_integration_tests/CRISPResso', line)
     return line
 
 


### PR DESCRIPTION
The Regex for matching the output line was too strict making it so it couldn't run on Github actions. This new version still passes all tests locally but also passes on github actions.