### PR TITLE
Implement warnings and `update-all`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,9 @@ if [ "$(filter test, $(MAKECMDGOALS))" != "" ]; then \
 fi && \
 if [ "$(filter update, $(MAKECMDGOALS))" != "" ]; then \
  python ../test_manager.py update $(subst cli_integration_tests/,./,$@) $(subst cli_integration_tests/,./expected_results/,$@); \
+fi && \
+if [ "$(filter update-all, $(MAKECMDGOALS))" != "" ]; then \
+ yes | python ../test_manager.py update $(subst cli_integration_tests/,./,$@) $(subst cli_integration_tests/,./expected_results/,$@); \
 fi
 endef
 
@@ -49,6 +52,9 @@ test:
 	@echo " ";
 
 update:
+	@echo " ";
+
+update-all:
 	@echo " ";
 
 install: $(CRISPRESSO2_SOURCES)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ python test_manager.py update <actual CRISPResso results directory> <expected CR
 
 This will show you what is different in the files, and then you can select whether you want them copied over or not.
 
+You can also run it through `make`:
+
+``` shell
+make <test case> update
+```
+
+The above will prompt you to confirm if you want each change.
+
+If you are very confident in each change, you can use `update-all`:
+
+``` shell
+make <test case> update-all
+```
+
+This will automatically update the files for you, then you can review the changes in git. **Use this wisely!**
+
 ### How can I add a test?
 
 If you want to add a test, you can run the command:

--- a/diff.py
+++ b/diff.py
@@ -107,7 +107,7 @@ def print_diff(diff_results):
         with tempfile.NamedTemporaryFile(mode='w') as fh:
             fh.writelines(''.join(diff_results))
             fh.flush()
-            subprocess.check_call(f'cat {fh.name} | ydiff -s -w 0 --wrap', shell=True)
+            subprocess.check_call(f'cat {fh.name} | ydiff -s -w 0 --wrap -p cat', shell=True)
     else:
         for line in diff_results:
             print(line, end='')

--- a/diff.py
+++ b/diff.py
@@ -28,6 +28,7 @@ IGNORE_FILES = frozenset([
     'CRISPRessoWGS_RUNNING_LOG.txt',
     'CRISPRessoCompare_RUNNING_LOG.txt',
 ])
+WARNING_FILE_REGEXP = re.compile(r'CRISPResso2_report.html')
 
 
 def which(program):
@@ -151,19 +152,22 @@ def diff_dir(actual, expected, suffixes=('.txt', '.html', '.sam'), prompt_to_upd
                     file_path_actual, files_expected[file_basename_actual],
                 ))
                 print_diff(diff_results)
-                diff_exists |= True
+                if not WARNING_FILE_REGEXP.search(str(file_path_actual)):
+                    diff_exists |= True
                 if prompt_to_update:
                     update_file(file_path_actual, files_expected[file_basename_actual])
         else:
             print('New file in Actual ({0}) not found in Expected ({1})'.format(file_basename_actual, expected))
-            diff_exists |= True
+            if not WARNING_FILE_REGEXP.search(str(file_path_actual)):
+                diff_exists |= True
             if prompt_to_update:
                 update_file(file_path_actual, join(expected, file_basename_actual))
 
     for file_basename_expected in files_expected.keys():
         if file_basename_expected not in files_actual:
             print('Missing file {0} from Actual ({1})'.format(file_basename_expected, actual))
-            diff_exists |= True
+            if not WARNING_FILE_REGEXP.search(str(file_path_actual)):
+                diff_exists |= True
             if prompt_to_update:
                 remove_file(join(expected, file_basename_expected))
 


### PR DESCRIPTION
This PR makes it such that changes in the HTML will not cause the build to fail, but the changes will still be shown to the user, and the files can still be updated. This makes for less noisy GitHub Actions (per @kclem's request), while still maintaining robust testing.

This practically means that the HTML files should still be updated and maintained even if the GitHub Actions are passing!

This also adds the `update-all` target to the Makefile so that you don't have to put in `y` repeatedly for small, predictable changes. This should be used responsibly!